### PR TITLE
Feat:네이버/카카오 로그인(수정 필요)

### DIFF
--- a/myproject/myproject/settings.py
+++ b/myproject/myproject/settings.py
@@ -40,10 +40,20 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sites',
     
     'user',
     'post',
     'mypage',
+    
+    #allauth
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    
+    #provider 추가
+    'allauth.socialaccount.providers.naver',
+    'allauth.socialaccount.providers.kakao'
 ]
 
 MIDDLEWARE = [
@@ -54,6 +64,8 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    
+    'allauth.account.middleware.AccountMiddleware'
 ]
 
 ROOT_URLCONF = 'myproject.urls'
@@ -132,6 +144,50 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 MEDIA_URL = "image/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "image")
 # 실제로 파일이 저장되는 경로를 설정하는 값.
+
+AUTHENTICATION_BACKENDS = (
+    #추가 장고에서 사용자의 이름을 기준으로 로그인하도록 설정
+    'django.contrib.auth.backends.ModelBackend',
+
+    # 추가 'allauth'의 인증방식 추가
+    'allauth.account.auth_backends.AuthenticationBackend',
+
+)
+
+SOCIALACCOUNT_PROVIDERS = {
+    'naver': {
+        'APP': {
+            'client_id': 'Jv4Wh2RIa2zE1hnBmP2i',  # 네이버 개발자 센터에서 발급받은 client_id
+            'secret': 'Sk830tXd7W',  # 네이버 개발자 센터에서 발급받은 client_secret
+        },
+        'SCOPE': [
+            'name',    # 사용자의 이름
+            'email',   # 사용자의 이메일
+        ],
+        'AUTH_PARAMS': {
+            'access_type': 'online',  # 로그인 시 항상 'online' 상태로
+            'prompt': 'select_account',  # 계정 선택을 위한 팝업을 강제
+        }
+    },
+    
+    "kakao": {
+        "APP": {
+            "client_id": "157a910f7c1b7a2d85320bdd1af6b961",
+            "secret": "d72e04d7012873270d4ede2a72d7fc2e",
+            "key": ""
+        },
+        "SCOPE": [
+            "profile_nickname",
+            "profile_image"
+        ],
+        "AUTH_PARAMS": {
+            "access_type": "online",
+            "prompt": "select_account"
+        }
+    }
+}
+
+SITE_ID = 3
 
 
 LOGIN_REDIRECT_URL = '/user/'  # 로그인 성공 시 이동할 경로

--- a/myproject/myproject/urls.py
+++ b/myproject/myproject/urls.py
@@ -23,7 +23,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('user/', include('user.urls')),
     path('post/', include('post.urls')),
-    path('mypage/', include('mypage.urls'))
+    path('mypage/', include('mypage.urls')),
+    path('accounts/', include('allauth.urls'))
 ]
 
 if settings.DEBUG:

--- a/myproject/user/admin.py
+++ b/myproject/user/admin.py
@@ -1,3 +1,17 @@
+# user/admin.py
+
+from allauth.socialaccount.models import SocialApp
+from allauth.socialaccount.admin import SocialAppAdmin
 from django.contrib import admin
 
-# Register your models here.
+class CustomSocialAppAdmin(SocialAppAdmin):
+    def delete_model(self, request, obj):
+        # 먼저 사이트 연결 끊기
+        obj.sites.clear()  # 연결된 모든 사이트 삭제
+        
+        # 부모 클래스의 delete_model 호출하여 실제 삭제
+        super().delete_model(request, obj)
+
+# 이 CustomSocialAppAdmin을 사용하여 SocialApp 모델을 등록합니다.
+admin.site.unregister(SocialApp)  # 기존 등록된 SocialApp 제거
+admin.site.register(SocialApp, CustomSocialAppAdmin)  # CustomSocialAppAdmin 등록

--- a/myproject/user/apps.py
+++ b/myproject/user/apps.py
@@ -1,6 +1,11 @@
-from django.apps import AppConfig
+# user/apps.py
 
+from django.apps import AppConfig
 
 class UserConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'user'
+
+    def ready(self):
+        # 여기서는 아무것도 하지 않고, 다른 작업은 signals.py에서 처리
+        pass

--- a/myproject/user/templates/login.html
+++ b/myproject/user/templates/login.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>로그인</title>
 </head>
+{% load socialaccount %}
 <body>
     <h2>로그인</h2>
         <form method="POST">
@@ -19,5 +20,13 @@
         <h3>로그아웃 후 이 페이지로 왔다면 성공</h3>
         <h3>회원가입 후 이 페이지로 왔다면 성공</h3>
 
+        <h3>소셜 로그인</h3>
+        {% for provider in social_providers %}
+            <a href="{% provider_login_url provider.provider %}">{{ provider.name }} 로그인</a><br>
+        {% endfor %}
+
+        {% for provider in social_providers %}
+            <p>{{ provider.provider }}</p>  <!-- 제공자 이름 출력 -->
+        {% endfor %}
     </body>
 </html>

--- a/myproject/user/views.py
+++ b/myproject/user/views.py
@@ -1,13 +1,13 @@
 from django.shortcuts import render, redirect
 from django.contrib import auth
-from django.contrib.auth import authenticate, login, update_session_auth_hash
+from django.contrib.auth import authenticate, login, login as auth_login, update_session_auth_hash
 from .forms import SignUpForm, UserUpdateForm
 from .models import CustomUser
 from mypage.models import Profile
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.decorators import login_required
-
-
+from django.contrib.sites.shortcuts import get_current_site
+from allauth.socialaccount.models import SocialApp
 
 # Create your views here.
 
@@ -26,18 +26,41 @@ def signup_view(request):
     return render(request, 'signup.html', {'form':form})
 
 def login_view(request):
+    # SocialApp에서 provider를 필터링하여 첫 번째 항목만 가져오기
+    social_providers = []
+    for provider in ['naver', 'kakao']:  # 필터링할 provider 목록
+        app = SocialApp.objects.filter(provider=provider).first()  # 첫 번째 항목만 가져오기
+        if app:  # 해당 프로바이더가 존재하는 경우에만 추가
+            social_providers.append({
+                'id': app.id,
+                'name': app.provider,
+                'provider': app.provider
+            })
+
+    print(social_providers)  # social_providers 출력해서 확인
+
+    # POST 요청일 경우 로그인 처리
     if request.method == 'POST':
-        username = request.POST['username']
-        password = request.POST['password']
+        username = request.POST.get('username')
+        password = request.POST.get('password')
+
+        # 사용자 인증
         user = authenticate(request, username=username, password=password)
-        
-        if user is not None:
-            auth.login(request, user)
-            return render(request, 'main.html')
+
+        if user:
+            auth_login(request, user)
+            return render(request, 'main.html')  # 로그인 성공 시 메인 페이지로 이동
         else:
-            return render(request, 'login.html')
-    else:
-        return render(request, 'login.html')
+            return render(request, 'login.html', {
+                'error': '아이디 또는 비밀번호가 잘못되었습니다.',
+                'social_providers': social_providers
+            })
+
+    # GET 요청일 경우 로그인 페이지 렌더링
+    return render(request, 'login.html', {
+        'social_providers': social_providers
+    })
+    
     
 def logout_view(request):
     auth.logout(request)


### PR DESCRIPTION
네이버와 카카오로부터 api를 받아와 로그인 시 연동되게 구현

1. 네이버 : 처음 로그인할 때는 자동 로그인이 되나, 뒤이어 로그인할 때 첫 계정으로 자동 로그인 되는 문제점.
2. 카카오 : 로그인 창까지는 이동하나, 로그인을 설정에서 막아놨다는 메시지가 떠서 로그인 불가능한 문제점.